### PR TITLE
ViewSession: show error for invalid arguments

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ViewSessionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewSessionCommandParser.java
@@ -19,7 +19,7 @@ public class ViewSessionCommandParser implements Parser<ViewSessionCommand> {
         ArgumentMultimap mm = ArgumentTokenizer.tokenize(args, PREFIX_DAY);
 
         if (!mm.getValue(PREFIX_DAY).isPresent() || !mm.getPreamble().isEmpty()) {
-            throw new ParseException("invalid command format. " + ViewSessionCommand.MESSAGE_USAGE);
+            throw new ParseException("Invalid command format!\n" + ViewSessionCommand.MESSAGE_USAGE);
         }
 
         DayOfWeek day = parseDay(mm.getValue(PREFIX_DAY).get().trim());


### PR DESCRIPTION
Add explicit message Invalid command format!\n when viewsession is invoked with unsupported arguments. Improves feedback and aligns with parser error-path conventions. No behavior change beyond message emission.

Resolves: #112 